### PR TITLE
Reset tuque variable to make sure auth is correct

### DIFF
--- a/ou_bagit_importer.module
+++ b/ou_bagit_importer.module
@@ -11,6 +11,8 @@ define('OU_BAGIT_IMPORTER_OBJECT_NAMESPACE', 'islandora');
  * Creates/Updates a book collection.
  */
 function ou_bagit_importer_save_book_collection($object_array, $json_recipe, $parent_collection) {
+  // Reset because we want to make sure tuque is connecting with the right credentials 	 
+  drupal_static_reset('islandora_get_tuque_connection');
   $tuque = islandora_get_tuque_connection();
   $uuid = OU_BAGIT_IMPORTER_OBJECT_NAMESPACE . ":{$object_array['uuid']}";
   $islandora_object = islandora_object_load($uuid);
@@ -119,6 +121,8 @@ function ou_bagit_importer_save_book_collection($object_array, $json_recipe, $pa
  * Creates/Updates a book page .
  */
 function ou_bagit_importer_save_book_page($object_array, $json_recipe) {
+  // Reset because we want to make sure tuque is connecting with the right credentials
+  drupal_static_reset('islandora_get_tuque_connection');
   $tuque = islandora_get_tuque_connection();
   $uuid = OU_BAGIT_IMPORTER_OBJECT_NAMESPACE . ":" . $object_array['uuid'];
   $islandora_object = islandora_object_load($uuid);


### PR DESCRIPTION
When drush bootstraps Drupal and the default home page is set to Fedora content, the tuque object will have  been created before the user gets set by Drush so it will have anonymous  access only. 

This resets the tuque object